### PR TITLE
RFC: Improve Cloud Chaos Providers

### DIFF
--- a/text/2023-06-14-cloud-chaos-improvements.md
+++ b/text/2023-06-14-cloud-chaos-improvements.md
@@ -40,7 +40,9 @@ Currently, none of these types use `Selectors` currently.  We should use the
 `RecordsController` with the `impl.Select` to lookup matching resources in the
 cloud and save these in the `records` as described
 [here](https://github.com/chaos-mesh/chaos-mesh/tree/master/controllers/common/records#readme)
+Since `filters` field is new, it is not a breaking change, so it is safe to update the existing chaos types.
 
+The initial types AWSChaos, GCPChaos and AzureChaos represent the common Instance or VirtualMachine resource types.  CloudProviders have many different resource types that we may want to target for chaos in future.  We can introduce new chaos experiment types for these, such as AWSNetworkChaos or AWSAutoscalerChaos.
 
 ## Detailed design
 
@@ -90,6 +92,13 @@ spec:
   duration: '5m'
 ```
 
+Supported filters are described in the Google Cloud Compute Engine reference.  For details see:
+https://cloud.google.com/compute/docs/reference/rest/v1/instances/list
+
+If multiple filters are provided, they will be combined with an AND expression.
+
+
+
 ## Drawbacks
 
 
@@ -107,13 +116,11 @@ spec:
 
 ## Unresolved questions
 
-- Should new chaos types be introduced for additional cloud resource types?
+- How to filter VMs list using Azure SDK.
 
-   It might be necessary to introduce new chaos types e.g. AWSNetworkChaos,
-   GCPNetworkChaos and so on.
+  Documentation isn't the best.  Also the autorest library used in chaos-mesh
+  is out of support: https://github.com/Azure/go-autorest
 
-   It might be necessary to make breaking changes to the structures, so it 
-   in this case it would be easier to introduce new types and eventually
-   deprecate the old ones.
-
-   We need to explore the solution in more detail before we can decide.
+  The following does work:  `az vm list -d --query "[?tags.env=='staging']"`
+  but I couldn't easily find how to do this in the golang SDK.  Have asked on
+  gophers slack.

--- a/text/2023-06-14-cloud-chaos-improvements.md
+++ b/text/2023-06-14-cloud-chaos-improvements.md
@@ -1,0 +1,52 @@
+# Chaos Types for Cloud Providers
+
+## Summary
+
+The current ASWChaos, GCPChaos and AzureChaos experiment types are quite basic.  We would like to improve them and add more types for different cloud resources such as networking.
+
+## Motivation
+
+We would like to use chaos-mesh to orchestrate more complex testing in cloud environments.
+
+For example, when stopping an instance it should be possible to select by name, tags or labels, instance type, availability zone, and other properties as supported by the cloud provider.
+
+Additionally, it would be useful to simulate outages by changing network ACLs in a similar way to how NetworkChaos works.
+
+Currently AWSChaos targets a single instance by InstanceID.  It does not really support selectors and `mode` such as `one`, `all` or `fixed-percent`.
+
+GCPChaos targets a single instance by `name` only.
+
+AzureChaos targets VM by `resource_group` and `name` and does have a `mode` parameter.  Behaviour of `mode` if `name` is not specified is not documented.
+
+It would be good to make these types similar, so users of chaos-mesh with multiple cloud providers can create similar experiments easily across all clouds.  However since we rely on the underlying SDK libraries from each provider, it seems sensible that we should keep close the the naming conventions used in the SDK.
+
+Currently, none of these types use `Selectors` currently.  We should use the `RecordsController` with the `impl.Select` to lookup matching resources in the cloud and save these in the `records` as described [here](https://github.com/chaos-mesh/chaos-mesh/tree/master/controllers/common/records#readme)
+
+
+## Detailed design
+
+
+## Drawbacks
+
+
+## Alternatives
+
+- Cloud extensions to live in a seperate repository
+
+   It would perhaps be more scalable for the cloud provider types to live in 
+   separate source repositories, allowing them to be maintained without impacting
+   the main chaos-mesh code base.
+
+   However this doesn't seem feasible at this time.  We would need some kind of 
+   plugin / exnension model to support this.
+
+- Extend the existing AWSChaos, GCPChaos and AzureChaos types
+
+   It might be simpler to add code to the existing types.  However, there are a 
+   potentially large number of different cloud resource types, so this would not 
+   scale well.
+
+   In addition we might require breaking changes to the structures, so it would be 
+   easier to introduce new types and eventually deprecate the old ones.
+
+## Unresolved questions

--- a/text/2023-06-14-cloud-chaos-improvements.md
+++ b/text/2023-06-14-cloud-chaos-improvements.md
@@ -12,11 +12,11 @@ For example, when stopping an instance it should be possible to select by name, 
 
 Additionally, it would be useful to simulate outages by changing network ACLs in a similar way to how NetworkChaos works.
 
-Currently AWSChaos targets a single instance by InstanceID.  It does not really support selectors and `mode` such as `one`, `all` or `fixed-percent`.
-
-GCPChaos targets a single instance by `name` only.
-
-AzureChaos targets VM by `resource_group` and `name` and does have a `mode` parameter.  Behaviour of `mode` if `name` is not specified is not documented.
+| ChaosType | Selector | Notes |
+| --------- | -------- | ----- |
+| AWSChaos  | Single instance by `InstanceID`| No support for selectors |
+| GCPChaos  | Single instance by `name`| No support for selectors |
+| AzureChaos | Single instance by `resource_group` and `name`| Docs does mention a `mode` parameter, but behavious is not documented |
 
 It would be good to make these types similar, so users of chaos-mesh with multiple cloud providers can create similar experiments easily across all clouds.  However since we rely on the underlying SDK libraries from each provider, it seems sensible that we should keep close the the naming conventions used in the SDK.
 

--- a/text/2023-06-14-cloud-chaos-improvements.md
+++ b/text/2023-06-14-cloud-chaos-improvements.md
@@ -2,25 +2,38 @@
 
 ## Summary
 
-The current ASWChaos, GCPChaos and AzureChaos experiment types are quite basic.  We would like to improve them and add more types for different cloud resources such as networking.
+The current ASWChaos, GCPChaos and AzureChaos experiment types are quite basic.
+We would like to improve them and add more types for different cloud resources
+such as networking.
 
 ## Motivation
 
-We would like to use chaos-mesh to orchestrate more complex testing in cloud environments.
+We would like to use chaos-mesh to orchestrate more complex testing in cloud
+environments.
 
-For example, when stopping an instance it should be possible to select by name, tags or labels, instance type, availability zone, and other properties as supported by the cloud provider.
+For example, when stopping an instance it should be possible to select by name,
+tags or labels, instance type, availability zone, and other properties as
+supported by the cloud provider.
 
-Additionally, it would be useful to simulate outages by changing network ACLs in a similar way to how NetworkChaos works.
+Additionally, it would be useful to simulate outages by changing network ACLs
+in a similar way to how NetworkChaos works.
 
 | ChaosType | Selector | Notes |
 | --------- | -------- | ----- |
 | AWSChaos  | Single instance by `InstanceID`| No support for selectors |
 | GCPChaos  | Single instance by `name`| No support for selectors |
-| AzureChaos | Single instance by `resource_group` and `name`| Docs does mention a `mode` parameter, but behavious is not documented |
+| AzureChaos | Single instance by `resource_group` and `name`| Docs does
+mention a`mode` parameter, but behavious is not documented |
 
-It would be good to make these types similar, so users of chaos-mesh with multiple cloud providers can create similar experiments easily across all clouds.  However since we rely on the underlying SDK libraries from each provider, it seems sensible that we should keep close the the naming conventions used in the SDK.
+It would be good to make these types similar, so users of chaos-mesh with
+multiple cloud providers can create similar experiments easily across all
+clouds.  However since we rely on the underlying SDK libraries from each
+provider, it seems sensible that we should keep close the the naming
+conventions used in the SDK.
 
-Currently, none of these types use `Selectors` currently.  We should use the `RecordsController` with the `impl.Select` to lookup matching resources in the cloud and save these in the `records` as described [here](https://github.com/chaos-mesh/chaos-mesh/tree/master/controllers/common/records#readme)
+Currently, none of these types use `Selectors` currently.  We should use the
+`RecordsController` with the `impl.Select` to lookup matching resources in the
+cloud and save these in the `records` as described [here](https://github.com/chaos-mesh/chaos-mesh/tree/master/controllers/common/records#readme)
 
 
 ## Detailed design
@@ -34,19 +47,19 @@ Currently, none of these types use `Selectors` currently.  We should use the `Re
 - Cloud extensions to live in a seperate repository
 
    It would perhaps be more scalable for the cloud provider types to live in 
-   separate source repositories, allowing them to be maintained without impacting
-   the main chaos-mesh code base.
+   separate source repositories, allowing them to be maintained without
+   impacting the main chaos-mesh code base.
 
-   However this doesn't seem feasible at this time.  We would need some kind of 
-   plugin / exnension model to support this.
+   However this doesn't seem feasible at this time.  We would need some kind
+   of plugin / exnension model to support this.
 
 - Extend the existing AWSChaos, GCPChaos and AzureChaos types
 
-   It might be simpler to add code to the existing types.  However, there are a 
-   potentially large number of different cloud resource types, so this would not 
-   scale well.
+   It might be simpler to add code to the existing types.  However, there are
+   a potentially large number of different cloud resource types, so this would
+   not scale well.
 
-   In addition we might require breaking changes to the structures, so it would be 
-   easier to introduce new types and eventually deprecate the old ones.
+   In addition we might require breaking changes to the structures, so it would
+   be easier to introduce new types and eventually deprecate the old ones.
 
 ## Unresolved questions


### PR DESCRIPTION
Initial thoughts about improving the support for chaos experiments using cloud providers infrastructure.

[preview](https://github.com/miketonks/rfcs/blob/mike-cloud-chaos/text/2023-06-14-cloud-chaos-improvements.md)